### PR TITLE
fix calculation of new id based on an empty list

### DIFF
--- a/services/contact-service.js
+++ b/services/contact-service.js
@@ -24,7 +24,7 @@ export default class ContactService {
     }
 
     add(data) {
-        data.id = Math.max(..._list.map(it => it.id)) + 1 || 1
+        data.id = Math.max(0, ..._list.map(it => it.id)) + 1
         _list.push(data)
         return data.id
     }


### PR DESCRIPTION
The id would be null led to fail updating contact when all contacts was removed.

The reason is `Math.max(...[])` would be `-Infinity`, and `-Infinity || 1` would be still -Infinity.

Please refer to the following question: 
http://stackoverflow.com/questions/42719786/why-math-max-is-equal-to-infinity-in-es2015#comment72559663_42719786